### PR TITLE
Add shadow to text in nav and fix dropdown

### DIFF
--- a/src/components/Banner.css
+++ b/src/components/Banner.css
@@ -8,6 +8,7 @@ margin: 0;
     color: rgb(255, 255, 255);
     padding-bottom: 1%;
     font-size: 3rem;
+    text-shadow: 5px 5px 10px #000;
 }
 .banner-buttons{
     margin-left: 30px;
@@ -17,11 +18,9 @@ margin: 0;
 }
 .banner-description{
     margin-left: 30px;
-    
     margin-right: 40%;
-
-
     color: rgb(255, 255, 255);
+    text-shadow: 0px 0px 5px #000;
 }
 .fade-bottom{
     height:100px;

--- a/src/components/Nav.css
+++ b/src/components/Nav.css
@@ -1,6 +1,6 @@
 .nav{
     height: 10%;
-
+    display: flex;
     width: 100%;
     top: 0;
     justify-content: space-between;
@@ -18,6 +18,7 @@
     
     background-color: transparent;
     position: fixed;
+    
 }
 .App-logo {
   margin: 1%;

--- a/src/components/dropdown.css
+++ b/src/components/dropdown.css
@@ -4,7 +4,6 @@
     /* border-radius: 20px; */
     /* height: 80%; */
     /* padding: auto; */
-    width: 100%;
     
     /* scroll-behavior: auto; */
     /* width: 194.4px; */


### PR DESCRIPTION
The text in the nav component blended with the background if it was too clear. Also, the wrapper 100% width made the dropdown be ordered in form of a column instead of a row.